### PR TITLE
Feature/higher half, closes #6

### DIFF
--- a/link.ld
+++ b/link.ld
@@ -1,23 +1,45 @@
 ENTRY(_start)
 
+KERNEL_ADDR_OFFSET = 0xC0000000;
+
 SECTIONS {
 	. = 1M;
+	KERNEL_PHYSADDR_START = .;
 
-	.text : ALIGN(4K) {
-		KEEP(*(.multiboot))
+	.rodata.boot : {
+		*(.rodata.boot)
+	}
+
+	.text.boot : {
+		*(.text.boot)
+	}
+
+	. = KERNEL_ADDR_OFFSET;
+	KERNEL_VADDR_START = .;
+
+	.text ALIGN(4K) : AT (ADDR(.text) - KERNEL_ADDR_OFFSET) {
 		*(.text)
 	}
 
-	.rodata : ALIGN(4K) {
+	.rodata ALIGN(4K) : AT (ADDR(.rodata) - KERNEL_ADDR_OFFSET) {
 		*(.rodata)
 	}
 
-	.data : ALIGN(4K) {
+	.data ALIGN(4K) : AT (ADDR(.data) - KERNEL_ADDR_OFFSET) {
 		*(.data)
 	}
 
-	.bss : ALIGN(4K) {
+	.bss ALIGN(4K) : AT (ADDR(.bss) - KERNEL_ADDR_OFFSET) {
 		*(COMMON)
 		*(.bss)
 	}
+
+	.bss.stack ALIGN(4K) : AT (ADDR(.bss.stack) - KERNEL_ADDR_OFFSET) {
+		*(.bss.stack)
+        KERNEL_STACK_END = .;
+    }
+
+	KERNEL_VADDR_END = .;
+	KERNEL_PHYSADDR_END = . - KERNEL_ADDR_OFFSET;
+
 }

--- a/src/kernel/kmain.zig
+++ b/src/kernel/kmain.zig
@@ -30,6 +30,8 @@ const KERNEL_NUM_PAGES = 1;
 
 // The initial page directory used for booting into the higher half. Should be overwritten later
 export var boot_page_directory: [1024]u32 align(4096) linksection(".rodata.boot") = init: {
+    // Increase max number of branches done by comptime evaluator
+    @setEvalBranchQuota(1024);
     // Temp value
     var dir: [1024]u32 = undefined;
 

--- a/src/kernel/kmain.zig
+++ b/src/kernel/kmain.zig
@@ -41,28 +41,29 @@ export var boot_page_directory: [1024]u32 align(4096) linksection(".rodata.boot"
     var i = 0;
     var idx = 1;
 
-    // Fill preceding pages with zeroes. May not be unecessary but incurs no runtime cost
-    while (i < KERNEL_PAGE_NUMBER - 1) {
-        dir[idx] = 0;
+    // Fill preceding pages with zeroes. May be unecessary but incurs no runtime cost
+    while (i < KERNEL_PAGE_NUMBER - 1) : ({
         i += 1;
         idx += 1;
+    }) {
+        dir[idx] = 0;
     }
 
     // Map the kernel's higher half pages increasing by 4 MiB every time
     i = 0;
-    while (i < KERNEL_NUM_PAGES) {
+    while (i < KERNEL_NUM_PAGES) : ({
+        i += 1;
+        idx += 1;
+    }) {
         dir[idx] = 0x00000083 | (i << 22);
-        i += 1;
-        idx += 1;
     }
-    // Increase max number of branches done by comptime evaluator
-    @setEvalBranchQuota(1024);
-    // Fill suceeding pages with zeroes. May not be unecessary but incurs no runtime cost
+    // Fill suceeding pages with zeroes. May be unecessary but incurs no runtime cost
     i = 0;
-    while (i < 1024 - KERNEL_PAGE_NUMBER - KERNEL_NUM_PAGES) {
-        dir[idx] = 0;
+    while (i < 1024 - KERNEL_PAGE_NUMBER - KERNEL_NUM_PAGES) : ({
         i += 1;
         idx += 1;
+    }) {
+        dir[idx] = 0;
     }
     break :init dir;
 };


### PR DESCRIPTION
This patch puts the kernel in the higher half (3GiB) with a rudimentary page directory used to map in the kernel. Currently only 4MiB are mapped in, which will need to be increased as the binary size increases and we add a heap etc. (can be done by increasing KERNEL_NUM_PAGES as needed).

The control flow is as follows: _start (sets up paging) -> start_higher_half (sets up the stack) -> kmain

The usage of Zig's `newStackCall` has been replaced with explicit assembly since it was using ~10 instructions to do what should only take 2. I think this is because it has to work out the size of the stack, so I just put a label in the linker script that represents the end of the stack and reference that from the assembly. That's a cheap little optimisation.

Closes #6 