### PR TITLE
Add logging

### DIFF
--- a/src/kernel/arch/x86/arch.zig
+++ b/src/kernel/arch/x86/arch.zig
@@ -5,6 +5,7 @@ const gdt = @import("gdt.zig");
 const idt = @import("idt.zig");
 const irq = @import("irq.zig");
 const isr = @import("isr.zig");
+const log = @import("../../log.zig");
 
 pub const InterruptContext = struct {
     // Extra segments

--- a/src/kernel/arch/x86/gdt.zig
+++ b/src/kernel/arch/x86/gdt.zig
@@ -1,6 +1,7 @@
 // Zig version: 0.4.0
 
 const arch = @import("arch.zig");
+const log = @import("../../log.zig");
 
 const NUMBER_OF_ENTRIES: u16 = 0x06;
 const TABLE_SIZE: u16 = @sizeOf(GdtEntry) * NUMBER_OF_ENTRIES - 1;
@@ -295,6 +296,7 @@ pub fn setTssStack(esp0: u32) void {
 /// Initialise the Global Descriptor table
 ///
 pub fn init() void {
+    log.logInfo("Init gdt\n");
     // Initiate TSS
     gdt_entries[TSS_INDEX] = makeEntry(@ptrToInt(&tss), @sizeOf(TtsEntry) - 1, TSS_SEGMENT, 0);
 

--- a/src/kernel/arch/x86/idt.zig
+++ b/src/kernel/arch/x86/idt.zig
@@ -2,6 +2,7 @@
 
 const gdt = @import("gdt.zig");
 const arch = @import("arch.zig");
+const log = @import("../../log.zig");
 
 const NUMBER_OF_ENTRIES: u16 = 256;
 const TABLE_SIZE: u16 = @sizeOf(IdtEntry) * NUMBER_OF_ENTRIES - 1;
@@ -119,5 +120,6 @@ pub fn closeInterruptGate(index: u8) void {
 /// Initialise the Interrupt descriptor table
 ///
 pub fn init() void {
+    log.logInfo("Init idt\n");
     arch.lidt(&idt_ptr);
 }

--- a/src/kernel/kmain.zig
+++ b/src/kernel/kmain.zig
@@ -5,6 +5,7 @@ const arch = if (builtin.is_test) @import("../../test/kernel/arch_mock.zig") els
 const multiboot = @import("multiboot.zig");
 const tty = @import("tty.zig");
 const vga = @import("vga.zig");
+const log = @import("log.zig");
 const serial = @import("serial.zig");
 
 // Need to import this as we need the panic to be in the root source file, or zig will just use the
@@ -21,11 +22,14 @@ pub fn panic(msg: []const u8, error_return_trace: ?*builtin.StackTrace) noreturn
 pub export fn kmain(mb_info: *multiboot.multiboot_info_t, mb_magic: u32) void {
     if (mb_magic == multiboot.MULTIBOOT_BOOTLOADER_MAGIC) {
         // Booted with compatible bootloader
+        serial.init(serial.DEFAULT_BAUDRATE, serial.Port.COM1) catch unreachable;
+
+        log.logInfo("Init arch " ++ @tagName(builtin.arch) ++ "\n");
         arch.init();
         vga.init();
         tty.init();
-        serial.init(serial.DEFAULT_BAUDRATE, serial.Port.COM1) catch unreachable;
 
+        log.logInfo("Finished init\n");
         tty.print("Hello Pluto from kernel :)\n");
 
         // Enable interrupts

--- a/src/kernel/log.zig
+++ b/src/kernel/log.zig
@@ -1,0 +1,31 @@
+const serial = @import("serial.zig");
+const fmt = @import("std").fmt;
+
+pub const Level = enum {
+    INFO,
+    DEBUG,
+    WARNING,
+    ERROR
+};
+
+fn logCallback(context: void, str: []const u8) anyerror!void {
+    serial.writeString(str, serial.Port.COM1);
+}
+
+pub fn log(comptime level: Level, comptime format: []const u8, args: ...) void {
+    fmt.format({}, anyerror, logCallback, "[" ++ @tagName(level) ++ "] " ++ format, args) catch unreachable;
+}
+
+pub fn logInfo(comptime format: []const u8, args: ...) void {
+    log(Level.INFO, format, args);
+}
+
+pub fn logDebug(comptime format: []const u8, args: ...) void {
+    log(Level.DEBUG, format, args);
+}
+pub fn logWarning(comptime format: []const u8, args: ...) void {
+    log(Level.WARNING, format, args);
+}
+pub fn logError(comptime format: []const u8, args: ...) void {
+    log(Level.ERROR, format, args);
+}

--- a/src/kernel/tty.zig
+++ b/src/kernel/tty.zig
@@ -1,6 +1,7 @@
 // Zig version: 0.4.0
 
 const vga = @import("vga.zig");
+const log = @import("log.zig");
 
 const expectEqual = @import("std").testing.expectEqual;
 const expectError = @import("std").testing.expectError;
@@ -594,6 +595,7 @@ pub fn setColour(new_colour: u8) void {
 ///     blank
 ///
 pub fn init() void {
+    log.logInfo("Init tty\n");
     // Video buffer in higher half
     video_buffer = @intToPtr([*]volatile u16, 0xC00B8000)[0..VIDEO_BUFFER_SIZE];
     setColour(vga.entryColour(vga.COLOUR_LIGHT_GREY, vga.COLOUR_BLACK));


### PR DESCRIPTION
This patch adds serial logging on top of the serial interface from #41. Closes #40. Depends on #41 