### PR TITLE
Add runtime testing harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ zig-cache
 
 # Build dir
 bin/*
+*.pyc
+__pycache__

--- a/src/kernel/arch/x86/gdt.zig
+++ b/src/kernel/arch/x86/gdt.zig
@@ -305,4 +305,5 @@ pub fn init() void {
 
     // Load the TSS
     arch.ltr();
+    log.logInfo("Done\n");
 }

--- a/src/kernel/arch/x86/idt.zig
+++ b/src/kernel/arch/x86/idt.zig
@@ -122,4 +122,5 @@ pub fn closeInterruptGate(index: u8) void {
 pub fn init() void {
     log.logInfo("Init idt\n");
     arch.lidt(&idt_ptr);
+    log.logInfo("Done\n");
 }

--- a/src/kernel/arch/x86/pit.zig
+++ b/src/kernel/arch/x86/pit.zig
@@ -273,6 +273,7 @@ pub fn getFrequency() u32 {
 /// Initialise the PIT with a handler to IRQ 0.
 ///
 pub fn init() void {
+    log.logInfo("Init pit\n");
     // Set up counter 0 at 1000hz in a square wave mode counting in binary
     const f: u32 = 10000;
     setupCounter(OCW_SELECT_COUNTER_0, f, OCW_MODE_SQUARE_WAVE_GENERATOR | OCW_BINARY_COUNT_BINARY);
@@ -281,4 +282,5 @@ pub fn init() void {
 
     // Installs 'pitHandler' to IRQ0 (pic.IRQ_PIT)
     irq.registerIrq(pic.IRQ_PIT, pitHandler);
+    log.logInfo("Done\n");
 }

--- a/src/kernel/kmain.zig
+++ b/src/kernel/kmain.zig
@@ -32,10 +32,11 @@ pub export fn kmain(mb_info: *multiboot.multiboot_info_t, mb_magic: u32) void {
 
         log.logInfo("Init arch " ++ @tagName(builtin.arch) ++ "\n");
         arch.init(&mem_profile, &fixed_allocator.allocator);
+        log.logInfo("Arch init done\n");
         vga.init();
         tty.init();
 
-        log.logInfo("Finished init\n");
+        log.logInfo("Init done\n");
         tty.print("Hello Pluto from kernel :)\n");
     }
 }

--- a/src/kernel/tty.zig
+++ b/src/kernel/tty.zig
@@ -644,6 +644,7 @@ pub fn init() void {
     printLogo();
     displayPageNumber();
     updateCursor();
+    log.logInfo("Done\n");
 }
 
 fn resetGlobals() void {

--- a/test/kernel/arch/x86/rt-test.py
+++ b/test/kernel/arch/x86/rt-test.py
@@ -1,0 +1,6 @@
+def getTestCases(TestCase):
+    return [
+            TestCase("GDT init", [r"Init gdt", r"Done"]),
+            TestCase("IDT init", [r"Init idt", r"Done"]),
+            TestCase("PIT init", [r"Init pit", r".+", "Done"])
+        ]

--- a/test/rt-test.py
+++ b/test/rt-test.py
@@ -1,0 +1,64 @@
+import subprocess
+import signal
+import re
+import sys
+import datetime
+import os
+import importlib.util
+
+class TestCase:
+    def __init__(self, name, expected):
+        self.name = name
+        self.expected = expected
+
+def test_failure(case, exp, expected_idx, found):
+    print("FAILURE: %s #%d, expected '%s', found '%s'" %(case.name, expected_idx + 1, exp, found))
+    sys.exit(1)
+
+def test_pass(case, exp, expected_idx, found):
+    print("PASS: %s #%d, expected '%s', found '%s'" %(case.name, expected_idx + 1, exp, found))
+
+if __name__ == "__main__":
+    arch = sys.argv[1]
+    zig_path = sys.argv[2]
+    spec = importlib.util.spec_from_file_location("arch", "test/kernel/arch/" + arch + "/rt-test.py")
+    arch_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(arch_module)
+
+    # The list of log statements to look for before arch init is called
+    pre_archinit_cases = [
+            TestCase("Arch init starts", [r"Init arch \w+"])
+        ]
+    # The list of log statements to look for after arch init is called
+    post_archinit_cases = [
+            TestCase("Arch init finishes", [r"Arch init done"]),
+            TestCase("TTY init", [r"Init tty", r"Done"]),
+            TestCase("Init finishes", [r"Init done"])
+        ]
+    # All log statements to look for, including the arch-specific ones
+    cases = pre_archinit_cases + arch_module.getTestCases(TestCase) + post_archinit_cases
+
+    if len(cases) > 0:
+        proc = subprocess.Popen(zig_path + " build run -Drt-test=true", stdout=subprocess.PIPE, shell=True)
+        case_idx = 0
+        # Go through the cases
+        while case_idx < len(cases):
+            case = cases[case_idx]
+            expected_idx = 0
+            # Go through the expected log messages
+            while expected_idx < len(case.expected):
+                e = "\[INFO\] " + case.expected[expected_idx]
+                line = proc.stdout.readline().decode("utf-8")
+                if not line:
+                    break
+                line = line.strip()
+                pattern = re.compile(e)
+                # Pass if the line matches the expected pattern, else fail
+                if pattern.fullmatch(line):
+                    test_pass(case, e, expected_idx, line)
+                else:
+                    test_failure(case, e, expected_idx, line)
+                expected_idx += 1
+            case_idx += 1
+        proc.kill()
+    sys.exit(0)


### PR DESCRIPTION
This patch adds a python script that acts as a runtime testing harness (test/rt-test.py), a new parameter to `zig build`, as well as some extra log messages for proper testing. The test harness script imports the arch-specific rt testing script from its arch directory.

It is recommended to run pkill on the qemu process after doing the testing as the process doesn't seem to be killed all the time: `zig build test -Drt-test=true; pkill qemu-system-i38`.

I would like to extend this to do more rigorous testing with more log statements once I find out how to tell the difference between an rt-test build and normal build from within the source, as adding more logging from a normal build would only pollute things.

Closes #12 