### PR TITLE
Add arch.registerInterruptHandler

### DIFF
--- a/src/kernel/arch/x86/arch.zig
+++ b/src/kernel/arch/x86/arch.zig
@@ -178,3 +178,14 @@ pub fn haltNoInterrupts() noreturn {
         halt();
     }
 }
+
+///
+/// Register an interrupt handler. The interrupt number should be the arch-specific number.
+///
+/// Arguments:
+///     IN int: u16 - The arch-specific interrupt number to register for.
+///     IN handler: fn (ctx: *InterruptContext) void - The handler to assign to the interrupt.
+///
+pub fn registerInterruptHandler(int: u16, handler: fn (ctx: *InterruptContext) void) void {
+    irq.registerIrq(int, handler);
+}

--- a/test/kernel/arch_mock.zig
+++ b/test/kernel/arch_mock.zig
@@ -30,3 +30,12 @@ pub fn inb(port: u16) u8 {return 0;}
 /// event being waited.
 ///
 pub fn ioWait() void {}
+
+///
+/// Register an interrupt handler. The interrupt number should be the arch-specific number.
+///
+/// Arguments:
+///     IN int: u16 - The arch-specific interrupt number to register for.
+///     IN handler: fn (ctx: *InterruptContext) void - The handler to assign to the interrupt.
+///
+pub fn registerInterruptHandler(int: u16, ctx: fn (ctx: *InterruptContext) void) void {}


### PR DESCRIPTION
This patch adds `registerIntHandler(...)` to arch.zig. Closes #51 