### PR TITLE
Add continuous integration with Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Pluto
 
+[![Build Status](https://dev.azure.com/samueltebbs/pluto/_apis/build/status/SamTebbs33.pluto?branchName=develop)](https://dev.azure.com/samueltebbs/samueltebbs/_build/latest?definitionId=1&branchName=develop)
+
 ## Build
 Requires *xorriso* and the grub tools (such as *grub-mkrescue*).
 ```

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,40 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+trigger:
+- develop
+- feature/*
+
+pr:
+- develop
+- feature/*
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  zig_version: 0.4.0
+
+steps:
+- script: |
+    export PYTHONIOENCODING=utf8
+    wget $(curl -s 'https://ziglang.org/download/index.json' | python3 -c "import sys, json; print(json.load(sys.stdin)['$(zig_version)']['x86_64-linux']['tarball'])")
+    tar -xvf zig*
+  displayName: 'Download zig'
+
+- script: zig*/zig build
+  displayName: 'Build kernel'
+
+# Uncomment once mock testing is finished
+#- script: zig*/zig build test
+#  displayName: 'Mocked tests'
+
+- script: |
+    sudo apt-get update
+    sudo apt-get install qemu qemu-system --fix-missing
+  displayName: 'Download qemu'
+  
+- script: zig*/zig build test -Drt-test=true -Dzig-path=zig*/zig
+  displayName: 'Runtime tests'


### PR DESCRIPTION
This patch adds continuous integration with Azure Pipelines at:
https://dev.azure.com/samueltebbs/pluto/_build?definitionId=1. This will
download zig v0.4.0 (will change to master once we upgrade our source),
build the kernel, install qemu and do runtime testing (mock testing will
also need to be done once that is up and running). Closes #13