### PR TITLE
Add infrastructure for build options

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,5 +36,7 @@ steps:
     sudo apt-get install qemu qemu-system --fix-missing
   displayName: 'Download qemu'
   
-- script: zig*/zig build test -Drt-test=true -Dzig-path=zig*/zig
+- script: |
+    zig*/zig build -Drt-test=true
+    zig*/zig build test -Drt-test=true -Dzig-path=zig*/zig
   displayName: 'Runtime tests'

--- a/src/kernel/arch/x86/arch.zig
+++ b/src/kernel/arch/x86/arch.zig
@@ -45,7 +45,7 @@ const MemProfile = @import("../../mem.zig").MemProfile;
 ///
 /// Initialise the architecture
 ///
-pub fn init(mem_profile: *const MemProfile, allocator: *std.mem.Allocator) void {
+pub fn init(mem_profile: *const MemProfile, allocator: *std.mem.Allocator, comptime options: type) void {
     disableInterrupts();
 
     gdt.init();

--- a/src/kernel/kmain.zig
+++ b/src/kernel/kmain.zig
@@ -9,6 +9,7 @@ const vga = @import("vga.zig");
 const log = @import("log.zig");
 const serial = @import("serial.zig");
 const mem = @import("mem.zig");
+const options = @import("build_options");
 
 // Need to import this as we need the panic to be in the root source file, or zig will just use the
 // builtin panic and just loop, which is what we don't want
@@ -31,7 +32,7 @@ pub export fn kmain(mb_info: *multiboot.multiboot_info_t, mb_magic: u32) void {
         serial.init(serial.DEFAULT_BAUDRATE, serial.Port.COM1) catch unreachable;
 
         log.logInfo("Init arch " ++ @tagName(builtin.arch) ++ "\n");
-        arch.init(&mem_profile, &fixed_allocator.allocator);
+        arch.init(&mem_profile, &fixed_allocator.allocator, options);
         log.logInfo("Arch init done\n");
         vga.init();
         tty.init();


### PR DESCRIPTION
This patch adds the infrastructure for passing build options from build.zig to the source. At the moment the only option added is `rt_test` which will be used to run extensive runtime tests (#60). 

I added the config.zig file to hide the rather ugly build options file import from kmain.zig, much like we did with arch.zig.

Closes #59 