### PR TITLE
Add formatting check to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,3 +29,5 @@ jobs:
         sudo apt-get install qemu qemu-system --fix-missing
     - name: Run runtime tests
       run: zig*/zig build test -Drt-test=true ${{ matrix.build_mode }}
+    - name: Check formatting
+      run: zig*/zig fmt --check src

--- a/src/kernel/serial.zig
+++ b/src/kernel/serial.zig
@@ -13,15 +13,13 @@ const PARITY_BIT = false;
 
 pub const DEFAULT_BAUDRATE = 38400;
 
-const SerialError = error {
-    InvalidBaud
-};
+const SerialError = error{InvalidBaud};
 
 pub const Port = enum(u16) {
     COM1 = 0x3F8,
     COM2 = 0x2F8,
     COM3 = 0x3E8,
-    COM4 = 0x2E8
+    COM4 = 0x2E8,
 };
 
 // Compute a value that encodes the serial properties
@@ -69,7 +67,9 @@ pub fn init(baud: u32, port: Port) SerialError!void {
 }
 
 pub fn write(char: u8, port: Port) void {
-    while (!transmitIsEmpty(port)) { arch.halt();  }
+    while (!transmitIsEmpty(port)) {
+        arch.halt();
+    }
     arch.outb(@enumToInt(port), char);
 }
 


### PR DESCRIPTION
Adds a `zig fmt --check src` step to CI which checks that code formatting matches the chosen style. Closes #61 