### PR TITLE
Add log tests

### DIFF
--- a/src/kernel/kmain.zig
+++ b/src/kernel/kmain.zig
@@ -36,7 +36,11 @@ export fn kmain(mb_info: *multiboot.multiboot_info_t, mb_magic: u32) void {
         var buffer = mem_profile.vaddr_end[0..mem_profile.fixed_alloc_size];
         var fixed_allocator = std.heap.FixedBufferAllocator.init(buffer);
 
-        serial.init(serial.DEFAULT_BAUDRATE, serial.Port.COM1) catch unreachable;
+        serial.init(serial.DEFAULT_BAUDRATE, serial.Port.COM1) catch |e| {
+            panic_root(@errorReturnTrace(), "Failed to initialise serial: {}", e);
+        };
+        if (build_options.rt_test)
+            log.runtimeTests();
 
         log.logInfo("Init arch " ++ @tagName(builtin.arch) ++ "\n");
         arch.init(&mem_profile, &fixed_allocator.allocator, build_options);

--- a/src/kernel/log.zig
+++ b/src/kernel/log.zig
@@ -31,3 +31,19 @@ pub fn logWarning(comptime format: []const u8, args: ...) void {
 pub fn logError(comptime format: []const u8, args: ...) void {
     log(Level.ERROR, format, args);
 }
+
+pub fn runtimeTests() void {
+    inline for (@typeInfo(Level).Enum.fields) |field| {
+        const level = @field(Level, field.name);
+        log(level, "Test " ++ field.name ++ " level\n");
+        log(level, "Test " ++ field.name ++ " level with args {}, {}\n", "a", u32(1));
+        const logFn = switch (level) {
+            .INFO => logInfo,
+            .DEBUG => logDebug,
+            .WARNING => logWarning,
+            .ERROR => logError,
+        };
+        logFn("Test " ++ field.name ++ " function\n");
+        logFn("Test " ++ field.name ++ " function with args {}, {}\n", "a", u32(1));
+    }
+}

--- a/test/rt-test.py
+++ b/test/rt-test.py
@@ -31,7 +31,11 @@ def test_pass(case, exp, expected_idx, found):
 def get_pre_archinit_cases():
     return [
             TestCase("Serial tests", [r"c", r"123"], ""),
-            TestCase("Arch init starts", [r"Init arch \w+"]),
+            TestCase("Log info tests", [r"Test INFO level", r"Test INFO level with args a, 1", r"Test INFO function", r"Test INFO function with args a, 1"], "\[INFO\] "),
+            TestCase("Log debug tests", [r"Test DEBUG level", r"Test DEBUG level with args a, 1", r"Test DEBUG function", r"Test DEBUG function with args a, 1"], "\[DEBUG\] "),
+            TestCase("Log warning tests", [r"Test WARNING level", r"Test WARNING level with args a, 1", r"Test WARNING function", r"Test WARNING function with args a, 1"], "\[WARNING\] "),
+            TestCase("Log error tests", [r"Test ERROR level", r"Test ERROR level with args a, 1", r"Test ERROR function", r"Test ERROR function with args a, 1"], "\[ERROR\] "),
+            TestCase("Arch init starts", [r"Init arch \w+"])
         ]
 
 def get_post_archinit_cases():


### PR DESCRIPTION
This patch adds log runtime tests. They will fail until #100 is merged as it needs the `prefix` argument added to `TestCase`. Closes #99 