### PR TITLE
Load grub modules on mem init

### DIFF
--- a/src/kernel/arch/x86/arch.zig
+++ b/src/kernel/arch/x86/arch.zig
@@ -10,6 +10,7 @@ const pit = @import("pit.zig");
 const paging = @import("paging.zig");
 const syscalls = @import("syscalls.zig");
 const mem = @import("../../mem.zig");
+const multiboot = @import("../../multiboot.zig");
 const MemProfile = mem.MemProfile;
 
 /// The interrupt context that is given to a interrupt handler. It contains most of the registers
@@ -215,7 +216,7 @@ pub fn haltNoInterrupts() noreturn {
 ///     IN comptime options: type         - The build options that is passed to the kernel to be
 ///                                         used for run time testing.
 ///
-pub fn init(mem_profile: *const MemProfile, allocator: *Allocator, comptime options: type) void {
+pub fn init(mb_info: *multiboot.multiboot_info_t, mem_profile: *const MemProfile, allocator: *Allocator) void {
     disableInterrupts();
 
     gdt.init();
@@ -227,9 +228,9 @@ pub fn init(mem_profile: *const MemProfile, allocator: *Allocator, comptime opti
 
     pit.init();
 
-    paging.init(mem_profile, allocator);
+    paging.init(mb_info, mem_profile, allocator);
 
-    syscalls.init(options);
+    syscalls.init();
 
     enableInterrupts();
 }

--- a/src/kernel/arch/x86/syscalls.zig
+++ b/src/kernel/arch/x86/syscalls.zig
@@ -3,6 +3,7 @@ const testing = @import("std").testing;
 const assert = @import("std").debug.assert;
 const isr = @import("isr.zig");
 const log = @import("../../log.zig");
+const options = @import("build_options");
 
 /// The isr number associated with syscalls
 pub const INTERRUPT: u16 = 0x80;
@@ -235,7 +236,7 @@ inline fn syscallArg(ctx: *arch.InterruptContext, comptime arg_idx: u32) u32 {
 ///
 /// Initialise syscalls. Registers the isr associated with INTERRUPT.
 ///
-pub fn init(comptime options: type) void {
+pub fn init() void {
     log.logInfo("Init syscalls\n");
     isr.registerIsr(INTERRUPT, handle) catch unreachable;
     log.logInfo("Done\n");

--- a/test/mock/kernel/arch_mock.zig
+++ b/test/mock/kernel/arch_mock.zig
@@ -4,6 +4,7 @@ const mem = @import("mem_mock.zig");
 const MemProfile = mem.MemProfile;
 const gdt = @import("gdt_mock.zig");
 const idt = @import("idt_mock.zig");
+const multiboot = @import("../../../src/kernel/multiboot.zig");
 
 const mock_framework = @import("mock_framework.zig");
 pub const initTest = mock_framework.initTest;
@@ -86,7 +87,7 @@ pub fn haltNoInterrupts() noreturn {
     while (true) {}
 }
 
-pub fn init(mem_profile: *const MemProfile, allocator: *Allocator, comptime options: type) void {
+pub fn init(mb_info: *multiboot.multiboot_info_t, mem_profile: *const MemProfile, allocator: *Allocator) void {
     // I'll get back to this as this doesn't effect the GDT testing.
     // When I come on to the mem.zig testing, I'll fix :)
     //return mock_framework.performAction("init", void, mem_profile, allocator);

--- a/test/rt-test.py
+++ b/test/rt-test.py
@@ -35,6 +35,7 @@ def get_pre_archinit_cases():
             TestCase("Log debug tests", [r"Test DEBUG level", r"Test DEBUG level with args a, 1", r"Test DEBUG function", r"Test DEBUG function with args a, 1"], "\[DEBUG\] "),
             TestCase("Log warning tests", [r"Test WARNING level", r"Test WARNING level with args a, 1", r"Test WARNING function", r"Test WARNING function with args a, 1"], "\[WARNING\] "),
             TestCase("Log error tests", [r"Test ERROR level", r"Test ERROR level with args a, 1", r"Test ERROR function", r"Test ERROR function with args a, 1"], "\[ERROR\] "),
+            TestCase("Mem init", [r"Init mem", r"Done"]),
             TestCase("Arch init starts", [r"Init arch \w+"])
         ]
 


### PR DESCRIPTION
This patch stores the modules loaded by grub at boot time. Depends on #105 