### PR TITLE
Fix T(x) style casts

### DIFF
--- a/src/kernel/arch/x86/gdt.zig
+++ b/src/kernel/arch/x86/gdt.zig
@@ -346,7 +346,7 @@ var gdt_ptr: GdtPtr = GdtPtr{
 var tss: TtsEntry = TtsEntry{
     .prev_tss = 0,
     .esp0 = 0,
-    .ss0 = u32(KERNEL_DATA_OFFSET),
+    .ss0 = KERNEL_DATA_OFFSET,
     .esp1 = 0,
     .ss1 = 0,
     .esp2 = 0,
@@ -370,7 +370,7 @@ var tss: TtsEntry = TtsEntry{
     .gs = 0,
     .ldtr = 0,
     .trap = 0,
-    .io_permissions_base_offset = u16(@sizeOf(TtsEntry)),
+    .io_permissions_base_offset = @sizeOf(TtsEntry),
 };
 
 ///
@@ -448,67 +448,67 @@ fn mock_lgdt(ptr: *const GdtPtr) void {
 }
 
 test "GDT entries" {
-    expectEqual(u32(1), @sizeOf(AccessBits));
-    expectEqual(u32(1), @sizeOf(FlagBits));
-    expectEqual(u32(8), @sizeOf(GdtEntry));
-    expectEqual(u32(104), @sizeOf(TtsEntry));
-    expectEqual(u32(6), @sizeOf(GdtPtr));
+    expectEqual(@as(u32, 1), @sizeOf(AccessBits));
+    expectEqual(@as(u32, 1), @sizeOf(FlagBits));
+    expectEqual(@as(u32, 8), @sizeOf(GdtEntry));
+    expectEqual(@as(u32, 104), @sizeOf(TtsEntry));
+    expectEqual(@as(u32, 6), @sizeOf(GdtPtr));
 
     const null_entry = gdt_entries[NULL_INDEX];
-    expectEqual(u64(0), @bitCast(u64, null_entry));
+    expectEqual(@as(u64, 0), @bitCast(u64, null_entry));
 
     const kernel_code_entry = gdt_entries[KERNEL_CODE_INDEX];
-    expectEqual(u64(0xCF9A000000FFFF), @bitCast(u64, kernel_code_entry));
+    expectEqual(@as(u64, 0xCF9A000000FFFF), @bitCast(u64, kernel_code_entry));
 
     const kernel_data_entry = gdt_entries[KERNEL_DATA_INDEX];
-    expectEqual(u64(0xCF92000000FFFF), @bitCast(u64, kernel_data_entry));
+    expectEqual(@as(u64, 0xCF92000000FFFF), @bitCast(u64, kernel_data_entry));
 
     const user_code_entry = gdt_entries[USER_CODE_INDEX];
-    expectEqual(u64(0xCFFA000000FFFF), @bitCast(u64, user_code_entry));
+    expectEqual(@as(u64, 0xCFFA000000FFFF), @bitCast(u64, user_code_entry));
 
     const user_data_entry = gdt_entries[USER_DATA_INDEX];
-    expectEqual(u64(0xCFF2000000FFFF), @bitCast(u64, user_data_entry));
+    expectEqual(@as(u64, 0xCFF2000000FFFF), @bitCast(u64, user_data_entry));
 
     const tss_entry = gdt_entries[TSS_INDEX];
-    expectEqual(u64(0), @bitCast(u64, tss_entry));
+    expectEqual(@as(u64, 0), @bitCast(u64, tss_entry));
 
     expectEqual(TABLE_SIZE, gdt_ptr.limit);
 
-    expectEqual(u32(0), tss.prev_tss);
-    expectEqual(u32(0), tss.esp0);
-    expectEqual(u32(KERNEL_DATA_OFFSET), tss.ss0);
-    expectEqual(u32(0), tss.esp1);
-    expectEqual(u32(0), tss.ss1);
-    expectEqual(u32(0), tss.esp2);
-    expectEqual(u32(0), tss.ss2);
-    expectEqual(u32(0), tss.cr3);
-    expectEqual(u32(0), tss.eip);
-    expectEqual(u32(0), tss.eflags);
-    expectEqual(u32(0), tss.eax);
-    expectEqual(u32(0), tss.ecx);
-    expectEqual(u32(0), tss.edx);
-    expectEqual(u32(0), tss.ebx);
-    expectEqual(u32(0), tss.esp);
-    expectEqual(u32(0), tss.ebp);
-    expectEqual(u32(0), tss.esi);
-    expectEqual(u32(0), tss.edi);
-    expectEqual(u32(0), tss.es);
-    expectEqual(u32(0), tss.cs);
-    expectEqual(u32(0), tss.ss);
-    expectEqual(u32(0), tss.ds);
-    expectEqual(u32(0), tss.fs);
-    expectEqual(u32(0), tss.gs);
-    expectEqual(u32(0), tss.ldtr);
-    expectEqual(u16(0), tss.trap);
+    expectEqual(@as(u32, 0), tss.prev_tss);
+    expectEqual(@as(u32, 0), tss.esp0);
+    expectEqual(@as(u32, KERNEL_DATA_OFFSET), tss.ss0);
+    expectEqual(@as(u32, 0), tss.esp1);
+    expectEqual(@as(u32, 0), tss.ss1);
+    expectEqual(@as(u32, 0), tss.esp2);
+    expectEqual(@as(u32, 0), tss.ss2);
+    expectEqual(@as(u32, 0), tss.cr3);
+    expectEqual(@as(u32, 0), tss.eip);
+    expectEqual(@as(u32, 0), tss.eflags);
+    expectEqual(@as(u32, 0), tss.eax);
+    expectEqual(@as(u32, 0), tss.ecx);
+    expectEqual(@as(u32, 0), tss.edx);
+    expectEqual(@as(u32, 0), tss.ebx);
+    expectEqual(@as(u32, 0), tss.esp);
+    expectEqual(@as(u32, 0), tss.ebp);
+    expectEqual(@as(u32, 0), tss.esi);
+    expectEqual(@as(u32, 0), tss.edi);
+    expectEqual(@as(u32, 0), tss.es);
+    expectEqual(@as(u32, 0), tss.cs);
+    expectEqual(@as(u32, 0), tss.ss);
+    expectEqual(@as(u32, 0), tss.ds);
+    expectEqual(@as(u32, 0), tss.fs);
+    expectEqual(@as(u32, 0), tss.gs);
+    expectEqual(@as(u32, 0), tss.ldtr);
+    expectEqual(@as(u16, 0), tss.trap);
 
     // Size of TtsEntry will fit in a u16 as 104 < 65535 (2^16)
-    expectEqual(u16(@sizeOf(TtsEntry)), tss.io_permissions_base_offset);
+    expectEqual(@as(u16, @sizeOf(TtsEntry)), tss.io_permissions_base_offset);
 }
 
 test "makeEntry NULL" {
-    const actual = makeEntry(u32(0), u32(0), NULL_SEGMENT, NULL_FLAGS);
+    const actual = makeEntry(0, 0, NULL_SEGMENT, NULL_FLAGS);
 
-    const expected = u64(0);
+    const expected: u64 = 0;
     expectEqual(expected, @bitCast(u64, actual));
 }
 
@@ -523,7 +523,7 @@ test "makeEntry alternating bit pattern" {
         .present = 0,
     };
 
-    expectEqual(u8(0b01010101), @bitCast(u8, alt_access));
+    expectEqual(@as(u8, 0b01010101), @bitCast(u8, alt_access));
 
     const alt_flag = FlagBits{
         .reserved_zero = 1,
@@ -532,106 +532,106 @@ test "makeEntry alternating bit pattern" {
         .granularity = 0,
     };
 
-    expectEqual(u4(0b0101), @bitCast(u4, alt_flag));
+    expectEqual(@as(u4, 0b0101), @bitCast(u4, alt_flag));
 
-    const actual = makeEntry(u32(0b01010101010101010101010101010101), u20(0b01010101010101010101), alt_access, alt_flag);
+    const actual = makeEntry(0b01010101010101010101010101010101, 0b01010101010101010101, alt_access, alt_flag);
 
-    const expected = u64(0b0101010101010101010101010101010101010101010101010101010101010101);
+    const expected: u64 = 0b0101010101010101010101010101010101010101010101010101010101010101;
     expectEqual(expected, @bitCast(u64, actual));
 }
 
 test "setTssStack" {
     // Pre-testing
-    expectEqual(u32(0), tss.prev_tss);
-    expectEqual(u32(0), tss.esp0);
-    expectEqual(u32(KERNEL_DATA_OFFSET), tss.ss0);
-    expectEqual(u32(0), tss.esp1);
-    expectEqual(u32(0), tss.ss1);
-    expectEqual(u32(0), tss.esp2);
-    expectEqual(u32(0), tss.ss2);
-    expectEqual(u32(0), tss.cr3);
-    expectEqual(u32(0), tss.eip);
-    expectEqual(u32(0), tss.eflags);
-    expectEqual(u32(0), tss.eax);
-    expectEqual(u32(0), tss.ecx);
-    expectEqual(u32(0), tss.edx);
-    expectEqual(u32(0), tss.ebx);
-    expectEqual(u32(0), tss.esp);
-    expectEqual(u32(0), tss.ebp);
-    expectEqual(u32(0), tss.esi);
-    expectEqual(u32(0), tss.edi);
-    expectEqual(u32(0), tss.es);
-    expectEqual(u32(0), tss.cs);
-    expectEqual(u32(0), tss.ss);
-    expectEqual(u32(0), tss.ds);
-    expectEqual(u32(0), tss.fs);
-    expectEqual(u32(0), tss.gs);
-    expectEqual(u32(0), tss.ldtr);
-    expectEqual(u16(0), tss.trap);
-    expectEqual(u16(@sizeOf(TtsEntry)), tss.io_permissions_base_offset);
+    expectEqual(@as(u32, 0), tss.prev_tss);
+    expectEqual(@as(u32, 0), tss.esp0);
+    expectEqual(@as(u32, KERNEL_DATA_OFFSET), tss.ss0);
+    expectEqual(@as(u32, 0), tss.esp1);
+    expectEqual(@as(u32, 0), tss.ss1);
+    expectEqual(@as(u32, 0), tss.esp2);
+    expectEqual(@as(u32, 0), tss.ss2);
+    expectEqual(@as(u32, 0), tss.cr3);
+    expectEqual(@as(u32, 0), tss.eip);
+    expectEqual(@as(u32, 0), tss.eflags);
+    expectEqual(@as(u32, 0), tss.eax);
+    expectEqual(@as(u32, 0), tss.ecx);
+    expectEqual(@as(u32, 0), tss.edx);
+    expectEqual(@as(u32, 0), tss.ebx);
+    expectEqual(@as(u32, 0), tss.esp);
+    expectEqual(@as(u32, 0), tss.ebp);
+    expectEqual(@as(u32, 0), tss.esi);
+    expectEqual(@as(u32, 0), tss.edi);
+    expectEqual(@as(u32, 0), tss.es);
+    expectEqual(@as(u32, 0), tss.cs);
+    expectEqual(@as(u32, 0), tss.ss);
+    expectEqual(@as(u32, 0), tss.ds);
+    expectEqual(@as(u32, 0), tss.fs);
+    expectEqual(@as(u32, 0), tss.gs);
+    expectEqual(@as(u32, 0), tss.ldtr);
+    expectEqual(@as(u16, 0), tss.trap);
+    expectEqual(@as(u16, @sizeOf(TtsEntry)), tss.io_permissions_base_offset);
 
     // Call function
-    setTssStack(u32(100));
+    setTssStack(100);
 
     // Post-testing
-    expectEqual(u32(0), tss.prev_tss);
-    expectEqual(u32(100), tss.esp0);
-    expectEqual(u32(KERNEL_DATA_OFFSET), tss.ss0);
-    expectEqual(u32(0), tss.esp1);
-    expectEqual(u32(0), tss.ss1);
-    expectEqual(u32(0), tss.esp2);
-    expectEqual(u32(0), tss.ss2);
-    expectEqual(u32(0), tss.cr3);
-    expectEqual(u32(0), tss.eip);
-    expectEqual(u32(0), tss.eflags);
-    expectEqual(u32(0), tss.eax);
-    expectEqual(u32(0), tss.ecx);
-    expectEqual(u32(0), tss.edx);
-    expectEqual(u32(0), tss.ebx);
-    expectEqual(u32(0), tss.esp);
-    expectEqual(u32(0), tss.ebp);
-    expectEqual(u32(0), tss.esi);
-    expectEqual(u32(0), tss.edi);
-    expectEqual(u32(0), tss.es);
-    expectEqual(u32(0), tss.cs);
-    expectEqual(u32(0), tss.ss);
-    expectEqual(u32(0), tss.ds);
-    expectEqual(u32(0), tss.fs);
-    expectEqual(u32(0), tss.gs);
-    expectEqual(u32(0), tss.ldtr);
-    expectEqual(u16(0), tss.trap);
-    expectEqual(u16(@sizeOf(TtsEntry)), tss.io_permissions_base_offset);
+    expectEqual(@as(u32, 0), tss.prev_tss);
+    expectEqual(@as(u32, 100), tss.esp0);
+    expectEqual(@as(u32, KERNEL_DATA_OFFSET), tss.ss0);
+    expectEqual(@as(u32, 0), tss.esp1);
+    expectEqual(@as(u32, 0), tss.ss1);
+    expectEqual(@as(u32, 0), tss.esp2);
+    expectEqual(@as(u32, 0), tss.ss2);
+    expectEqual(@as(u32, 0), tss.cr3);
+    expectEqual(@as(u32, 0), tss.eip);
+    expectEqual(@as(u32, 0), tss.eflags);
+    expectEqual(@as(u32, 0), tss.eax);
+    expectEqual(@as(u32, 0), tss.ecx);
+    expectEqual(@as(u32, 0), tss.edx);
+    expectEqual(@as(u32, 0), tss.ebx);
+    expectEqual(@as(u32, 0), tss.esp);
+    expectEqual(@as(u32, 0), tss.ebp);
+    expectEqual(@as(u32, 0), tss.esi);
+    expectEqual(@as(u32, 0), tss.edi);
+    expectEqual(@as(u32, 0), tss.es);
+    expectEqual(@as(u32, 0), tss.cs);
+    expectEqual(@as(u32, 0), tss.ss);
+    expectEqual(@as(u32, 0), tss.ds);
+    expectEqual(@as(u32, 0), tss.fs);
+    expectEqual(@as(u32, 0), tss.gs);
+    expectEqual(@as(u32, 0), tss.ldtr);
+    expectEqual(@as(u16, 0), tss.trap);
+    expectEqual(@as(u16, @sizeOf(TtsEntry)), tss.io_permissions_base_offset);
 
     // Clean up
-    setTssStack(u32(0));
+    setTssStack(0);
 
-    expectEqual(u32(0), tss.prev_tss);
-    expectEqual(u32(0), tss.esp0);
-    expectEqual(u32(KERNEL_DATA_OFFSET), tss.ss0);
-    expectEqual(u32(0), tss.esp1);
-    expectEqual(u32(0), tss.ss1);
-    expectEqual(u32(0), tss.esp2);
-    expectEqual(u32(0), tss.ss2);
-    expectEqual(u32(0), tss.cr3);
-    expectEqual(u32(0), tss.eip);
-    expectEqual(u32(0), tss.eflags);
-    expectEqual(u32(0), tss.eax);
-    expectEqual(u32(0), tss.ecx);
-    expectEqual(u32(0), tss.edx);
-    expectEqual(u32(0), tss.ebx);
-    expectEqual(u32(0), tss.esp);
-    expectEqual(u32(0), tss.ebp);
-    expectEqual(u32(0), tss.esi);
-    expectEqual(u32(0), tss.edi);
-    expectEqual(u32(0), tss.es);
-    expectEqual(u32(0), tss.cs);
-    expectEqual(u32(0), tss.ss);
-    expectEqual(u32(0), tss.ds);
-    expectEqual(u32(0), tss.fs);
-    expectEqual(u32(0), tss.gs);
-    expectEqual(u32(0), tss.ldtr);
-    expectEqual(u16(0), tss.trap);
-    expectEqual(u16(@sizeOf(TtsEntry)), tss.io_permissions_base_offset);
+    expectEqual(@as(u32, 0), tss.prev_tss);
+    expectEqual(@as(u32, 0), tss.esp0);
+    expectEqual(@as(u32, KERNEL_DATA_OFFSET), tss.ss0);
+    expectEqual(@as(u32, 0), tss.esp1);
+    expectEqual(@as(u32, 0), tss.ss1);
+    expectEqual(@as(u32, 0), tss.esp2);
+    expectEqual(@as(u32, 0), tss.ss2);
+    expectEqual(@as(u32, 0), tss.cr3);
+    expectEqual(@as(u32, 0), tss.eip);
+    expectEqual(@as(u32, 0), tss.eflags);
+    expectEqual(@as(u32, 0), tss.eax);
+    expectEqual(@as(u32, 0), tss.ecx);
+    expectEqual(@as(u32, 0), tss.edx);
+    expectEqual(@as(u32, 0), tss.ebx);
+    expectEqual(@as(u32, 0), tss.esp);
+    expectEqual(@as(u32, 0), tss.ebp);
+    expectEqual(@as(u32, 0), tss.esi);
+    expectEqual(@as(u32, 0), tss.edi);
+    expectEqual(@as(u32, 0), tss.es);
+    expectEqual(@as(u32, 0), tss.cs);
+    expectEqual(@as(u32, 0), tss.ss);
+    expectEqual(@as(u32, 0), tss.ds);
+    expectEqual(@as(u32, 0), tss.fs);
+    expectEqual(@as(u32, 0), tss.gs);
+    expectEqual(@as(u32, 0), tss.ldtr);
+    expectEqual(@as(u16, 0), tss.trap);
+    expectEqual(@as(u16, @sizeOf(TtsEntry)), tss.io_permissions_base_offset);
 }
 
 test "init" {
@@ -651,13 +651,13 @@ test "init" {
     const tss_limit = @sizeOf(TtsEntry) - 1;
     const tss_addr = @ptrToInt(&tss);
 
-    var expected = u64(0);
-    expected |= u64(@truncate(u16, tss_limit));
-    expected |= u64(@truncate(u24, tss_addr)) << 16;
-    expected |= u64(0x89) << (16 + 24);
-    expected |= u64(@truncate(u4, tss_limit >> 16)) << (16 + 24 + 8);
+    var expected: u64 = 0;
+    expected |= @as(u64, @truncate(u16, tss_limit));
+    expected |= @as(u64, @truncate(u24, tss_addr)) << 16;
+    expected |= @as(u64, 0x89) << (16 + 24);
+    expected |= @as(u64, @truncate(u4, tss_limit >> 16)) << (16 + 24 + 8);
     // Flags are zero
-    expected |= u64(@truncate(u8, tss_addr >> 24)) << (16 + 24 + 8 + 4 + 4);
+    expected |= @as(u64, @truncate(u8, tss_addr >> 24)) << (16 + 24 + 8 + 4 + 4);
 
     expectEqual(expected, @bitCast(u64, tss_entry));
 

--- a/src/kernel/arch/x86/idt.zig
+++ b/src/kernel/arch/x86/idt.zig
@@ -198,16 +198,16 @@ fn mock_lidt(ptr: *const IdtPtr) void {
 }
 
 test "IDT entries" {
-    expectEqual(u32(8), @sizeOf(IdtEntry));
-    expectEqual(u32(6), @sizeOf(IdtPtr));
+    expectEqual(@as(u32, 8), @sizeOf(IdtEntry));
+    expectEqual(@as(u32, 6), @sizeOf(IdtPtr));
     expectEqual(TABLE_SIZE, idt_ptr.limit);
-    expectEqual(u32(0), idt_ptr.base);
+    expectEqual(@as(u32, 0), idt_ptr.base);
 }
 
 test "makeEntry alternating bit pattern" {
-    const actual = makeEntry(u32(0b01010101010101010101010101010101), u16(0b0101010101010101), u4(0b0101), u2(0b01));
+    const actual = makeEntry(0b01010101010101010101010101010101, 0b0101010101010101, 0b0101, 0b01);
 
-    const expected = u64(0b0101010101010101101001010000000001010101010101010101010101010101);
+    const expected: u64 = 0b0101010101010101101001010000000001010101010101010101010101010101;
 
     expectEqual(expected, @bitCast(u64, actual));
 }
@@ -240,7 +240,7 @@ test "isIdtOpen" {
 }
 
 test "openInterruptGate" {
-    const index = u8(100);
+    const index: u8 = 100;
     openInterruptGate(index, testHandler0) catch unreachable;
     expectError(IdtError.IdtEntryExists, openInterruptGate(index, testHandler0));
 

--- a/src/kernel/arch/x86/irq.zig
+++ b/src/kernel/arch/x86/irq.zig
@@ -148,7 +148,7 @@ test "openIrq" {
     idt.initTest();
     defer idt.freeTest();
 
-    const index = u8(0);
+    const index: u8 = 0;
     const handler = testFunction0;
     const ret: idt.IdtError!void = {};
 
@@ -171,7 +171,7 @@ test "registerIrq re-register irq handler" {
     pic.initTest();
     defer pic.freeTest();
 
-    pic.addTestParams("clearMask", u16(0));
+    pic.addTestParams("clearMask", @as(u16, 0));
 
     // Pre testing
     for (irq_handlers) |h| {
@@ -200,7 +200,7 @@ test "registerIrq register irq handler" {
     pic.initTest();
     defer pic.freeTest();
 
-    pic.addTestParams("clearMask", u16(0));
+    pic.addTestParams("clearMask", @as(u16, 0));
 
     // Pre testing
     for (irq_handlers) |h| {

--- a/src/kernel/arch/x86/isr.zig
+++ b/src/kernel/arch/x86/isr.zig
@@ -258,7 +258,7 @@ test "openIsr" {
     idt.initTest();
     defer idt.freeTest();
 
-    const index = u8(0);
+    const index: u8 = 0;
     const handler = testFunction0;
     const ret: idt.IdtError!void = {};
 

--- a/src/kernel/arch/x86/paging.zig
+++ b/src/kernel/arch/x86/paging.zig
@@ -190,10 +190,10 @@ fn mapDirEntry(dir: *Directory, virt_start: usize, virt_end: usize, phys_start: 
     var dir_entry = &dir.entries[entry];
     dir_entry.* |= DENTRY_PRESENT;
     dir_entry.* |= DENTRY_WRITABLE;
-    dir_entry.* &= ~u32(DENTRY_USER);
+    dir_entry.* &= ~DENTRY_USER;
     dir_entry.* |= DENTRY_WRITE_THROUGH;
-    dir_entry.* &= ~u32(DENTRY_CACHE_DISABLED);
-    dir_entry.* &= ~u32(DENTRY_4MB_PAGES);
+    dir_entry.* &= ~DENTRY_CACHE_DISABLED;
+    dir_entry.* &= ~DENTRY_4MB_PAGES;
 
     // Only create a new table if one hasn't already been created for this dir entry.
     // Prevents us from overriding previous mappings.
@@ -239,10 +239,10 @@ fn mapTableEntry(entry: *align(1) TableEntry, phys_addr: usize) PagingError!void
     }
     entry.* |= TENTRY_PRESENT;
     entry.* |= TENTRY_WRITABLE;
-    entry.* &= ~u32(TENTRY_USER);
+    entry.* &= ~TENTRY_USER;
     entry.* |= TENTRY_WRITE_THROUGH;
-    entry.* &= ~u32(TENTRY_CACHE_DISABLED);
-    entry.* &= ~u32(TENTRY_GLOBAL);
+    entry.* &= ~TENTRY_CACHE_DISABLED;
+    entry.* &= ~TENTRY_GLOBAL;
     entry.* |= TENTRY_PAGE_ADDR & @intCast(u32, phys_addr);
 }
 

--- a/src/kernel/arch/x86/pic.zig
+++ b/src/kernel/arch/x86/pic.zig
@@ -410,7 +410,7 @@ pub fn spuriousIrq(irq_num: u8) bool {
 pub fn setMask(irq_num: u8) void {
     const port: u16 = if (irq_num < 8) MASTER_DATA_REG else SLAVE_DATA_REG;
     const shift = @intCast(u3, irq_num % 8);
-    const value: u8 = arch.inb(port) | (u8(1) << shift);
+    const value: u8 = arch.inb(port) | (@as(u8, 1) << shift);
     arch.outb(port, value);
 }
 
@@ -423,7 +423,7 @@ pub fn setMask(irq_num: u8) void {
 pub fn clearMask(irq_num: u8) void {
     const port: u16 = if (irq_num < 8) MASTER_DATA_REG else SLAVE_DATA_REG;
     const shift = @intCast(u3, irq_num % 8);
-    const value: u8 = arch.inb(port) & ~(u8(1) << shift);
+    const value: u8 = arch.inb(port) & ~(@as(u8, 1) << shift);
     arch.outb(port, value);
 }
 
@@ -451,8 +451,8 @@ pub fn init() void {
     sendDataSlave(ICW4_80x86_MODE);
 
     // Mask all interrupts
-    sendDataMaster(u8(0xFF));
-    sendDataSlave(u8(0xFF));
+    sendDataMaster(0xFF);
+    sendDataSlave(0xFF);
 
     log.logInfo("Done\n");
 
@@ -464,7 +464,7 @@ test "sendCommandMaster" {
     arch.initTest();
     defer arch.freeTest();
 
-    const cmd = u8(10);
+    const cmd: u8 = 10;
 
     arch.addTestParams("outb", MASTER_COMMAND_REG, cmd);
 
@@ -476,7 +476,7 @@ test "sendCommandSlave" {
     arch.initTest();
     defer arch.freeTest();
 
-    const cmd = u8(10);
+    const cmd: u8 = 10;
 
     arch.addTestParams("outb", SLAVE_COMMAND_REG, cmd);
 
@@ -488,7 +488,7 @@ test "sendDataMaster" {
     arch.initTest();
     defer arch.freeTest();
 
-    const data = u8(10);
+    const data: u8 = 10;
 
     arch.addTestParams("outb", MASTER_DATA_REG, data);
 
@@ -500,7 +500,7 @@ test "sendDataSlave" {
     arch.initTest();
     defer arch.freeTest();
 
-    const data = u8(10);
+    const data: u8 = 10;
 
     arch.addTestParams("outb", SLAVE_DATA_REG, data);
 
@@ -512,9 +512,9 @@ test "readDataMaster" {
     arch.initTest();
     defer arch.freeTest();
 
-    arch.addTestParams("inb", MASTER_DATA_REG, u8(10));
+    arch.addTestParams("inb", MASTER_DATA_REG, @as(u8, 10));
 
-    expectEqual(u8(10), readDataMaster());
+    expectEqual(@as(u8, 10), readDataMaster());
 }
 
 test "readDataSlave" {
@@ -522,9 +522,9 @@ test "readDataSlave" {
     arch.initTest();
     defer arch.freeTest();
 
-    arch.addTestParams("inb", SLAVE_DATA_REG, u8(10));
+    arch.addTestParams("inb", SLAVE_DATA_REG, @as(u8, 10));
 
-    expectEqual(u8(10), readDataSlave());
+    expectEqual(@as(u8, 10), readDataSlave());
 }
 
 test "readMasterIrr" {
@@ -532,10 +532,10 @@ test "readMasterIrr" {
     arch.initTest();
     defer arch.freeTest();
 
-    arch.addTestParams("outb", MASTER_COMMAND_REG, u8(0x0A));
-    arch.addTestParams("inb", MASTER_STATUS_REG, u8(10));
+    arch.addTestParams("outb", MASTER_COMMAND_REG, @as(u8, 0x0A));
+    arch.addTestParams("inb", MASTER_STATUS_REG, @as(u8, 10));
 
-    expectEqual(u8(10), readMasterIrr());
+    expectEqual(@as(u8, 10), readMasterIrr());
 }
 
 test "readSlaveIrr" {
@@ -543,10 +543,10 @@ test "readSlaveIrr" {
     arch.initTest();
     defer arch.freeTest();
 
-    arch.addTestParams("outb", SLAVE_COMMAND_REG, u8(0x0A));
-    arch.addTestParams("inb", SLAVE_STATUS_REG, u8(10));
+    arch.addTestParams("outb", SLAVE_COMMAND_REG, @as(u8, 0x0A));
+    arch.addTestParams("inb", SLAVE_STATUS_REG, @as(u8, 10));
 
-    expectEqual(u8(10), readSlaveIrr());
+    expectEqual(@as(u8, 10), readSlaveIrr());
 }
 
 test "readMasterIsr" {
@@ -554,10 +554,10 @@ test "readMasterIsr" {
     arch.initTest();
     defer arch.freeTest();
 
-    arch.addTestParams("outb", MASTER_COMMAND_REG, u8(0x0B));
-    arch.addTestParams("inb", MASTER_STATUS_REG, u8(10));
+    arch.addTestParams("outb", MASTER_COMMAND_REG, @as(u8, 0x0B));
+    arch.addTestParams("inb", MASTER_STATUS_REG, @as(u8, 10));
 
-    expectEqual(u8(10), readMasterIsr());
+    expectEqual(@as(u8, 10), readMasterIsr());
 }
 
 test "readSlaveIsr" {
@@ -565,10 +565,10 @@ test "readSlaveIsr" {
     arch.initTest();
     defer arch.freeTest();
 
-    arch.addTestParams("outb", SLAVE_COMMAND_REG, u8(0x0B));
-    arch.addTestParams("inb", SLAVE_STATUS_REG, u8(10));
+    arch.addTestParams("outb", SLAVE_COMMAND_REG, @as(u8, 0x0B));
+    arch.addTestParams("inb", SLAVE_STATUS_REG, @as(u8, 10));
 
-    expectEqual(u8(10), readSlaveIsr());
+    expectEqual(@as(u8, 10), readSlaveIsr());
 }
 
 test "sendEndOfInterrupt master only" {
@@ -576,7 +576,7 @@ test "sendEndOfInterrupt master only" {
     arch.initTest();
     defer arch.freeTest();
 
-    var i = u8(0);
+    var i: u8 = 0;
     while (i < 8) : (i += 1) {
         arch.addTestParams("outb", MASTER_COMMAND_REG, OCW2_END_OF_INTERRUPT);
 
@@ -589,7 +589,7 @@ test "sendEndOfInterrupt master and slave" {
     arch.initTest();
     defer arch.freeTest();
 
-    var i = u8(8);
+    var i: u8 = 8;
     while (i < 16) : (i += 1) {
         arch.addTestParams("outb", SLAVE_COMMAND_REG, OCW2_END_OF_INTERRUPT);
         arch.addTestParams("outb", MASTER_COMMAND_REG, OCW2_END_OF_INTERRUPT);
@@ -600,9 +600,9 @@ test "sendEndOfInterrupt master and slave" {
 
 test "spuriousIrq not spurious IRQ number" {
     // Pre testing
-    expectEqual(u32(0), spurious_irq_counter);
+    expectEqual(@as(u32, 0), spurious_irq_counter);
 
-    var i = u8(0);
+    var i: u8 = 0;
     while (i < 16) : (i += 1) {
         if (i != 7 and i != 15) {
             expectEqual(false, spuriousIrq(i));
@@ -610,7 +610,7 @@ test "spuriousIrq not spurious IRQ number" {
     }
 
     // Post testing
-    expectEqual(u32(0), spurious_irq_counter);
+    expectEqual(@as(u32, 0), spurious_irq_counter);
 
     // Clean up
     spurious_irq_counter = 0;
@@ -621,18 +621,18 @@ test "spuriousIrq spurious master IRQ number not spurious" {
     arch.initTest();
     defer arch.freeTest();
 
-    arch.addTestParams("outb", MASTER_COMMAND_REG, u8(0x0B));
+    arch.addTestParams("outb", MASTER_COMMAND_REG, @as(u8, 0x0B));
     // Return 0x80 from readMasterIsr() which will mean this was a real IRQ
-    arch.addTestParams("inb", MASTER_STATUS_REG, u8(0x80));
+    arch.addTestParams("inb", MASTER_STATUS_REG, @as(u8, 0x80));
 
     // Pre testing
-    expectEqual(u32(0), spurious_irq_counter);
+    expectEqual(@as(u32, 0), spurious_irq_counter);
 
     // Call function
-    expectEqual(false, spuriousIrq(u8(7)));
+    expectEqual(false, spuriousIrq(7));
 
     // Post testing
-    expectEqual(u32(0), spurious_irq_counter);
+    expectEqual(@as(u32, 0), spurious_irq_counter);
 
     // Clean up
     spurious_irq_counter = 0;
@@ -643,18 +643,18 @@ test "spuriousIrq spurious master IRQ number spurious" {
     arch.initTest();
     defer arch.freeTest();
 
-    arch.addTestParams("outb", MASTER_COMMAND_REG, u8(0x0B));
+    arch.addTestParams("outb", MASTER_COMMAND_REG, @as(u8, 0x0B));
     // Return 0x0 from readMasterIsr() which will mean this was a spurious IRQ
-    arch.addTestParams("inb", MASTER_STATUS_REG, u8(0x0));
+    arch.addTestParams("inb", MASTER_STATUS_REG, @as(u8, 0x0));
 
     // Pre testing
-    expectEqual(u32(0), spurious_irq_counter);
+    expectEqual(@as(u32, 0), spurious_irq_counter);
 
     // Call function
-    expectEqual(true, spuriousIrq(u8(7)));
+    expectEqual(true, spuriousIrq(7));
 
     // Post testing
-    expectEqual(u32(1), spurious_irq_counter);
+    expectEqual(@as(u32, 1), spurious_irq_counter);
 
     // Clean up
     spurious_irq_counter = 0;
@@ -665,18 +665,18 @@ test "spuriousIrq spurious slave IRQ number not spurious" {
     arch.initTest();
     defer arch.freeTest();
 
-    arch.addTestParams("outb", SLAVE_COMMAND_REG, u8(0x0B));
+    arch.addTestParams("outb", SLAVE_COMMAND_REG, @as(u8, 0x0B));
     // Return 0x80 from readSlaveIsr() which will mean this was a real IRQ
-    arch.addTestParams("inb", SLAVE_STATUS_REG, u8(0x80));
+    arch.addTestParams("inb", SLAVE_STATUS_REG, @as(u8, 0x80));
 
     // Pre testing
-    expectEqual(u32(0), spurious_irq_counter);
+    expectEqual(@as(u32, 0), spurious_irq_counter);
 
     // Call function
-    expectEqual(false, spuriousIrq(u8(15)));
+    expectEqual(false, spuriousIrq(15));
 
     // Post testing
-    expectEqual(u32(0), spurious_irq_counter);
+    expectEqual(@as(u32, 0), spurious_irq_counter);
 
     // Clean up
     spurious_irq_counter = 0;
@@ -687,20 +687,20 @@ test "spuriousIrq spurious slave IRQ number spurious" {
     arch.initTest();
     defer arch.freeTest();
 
-    arch.addTestParams("outb", SLAVE_COMMAND_REG, u8(0x0B));
+    arch.addTestParams("outb", SLAVE_COMMAND_REG, @as(u8, 0x0B));
     // Return 0x0 from readSlaveIsr() which will mean this was a spurious IRQ
-    arch.addTestParams("inb", SLAVE_STATUS_REG, u8(0x0));
+    arch.addTestParams("inb", SLAVE_STATUS_REG, @as(u8, 0x0));
     // A EOI will be sent for a spurious IRQ 15
     arch.addTestParams("outb", MASTER_COMMAND_REG, OCW2_END_OF_INTERRUPT);
 
     // Pre testing
-    expectEqual(u32(0), spurious_irq_counter);
+    expectEqual(@as(u32, 0), spurious_irq_counter);
 
     // Call function
-    expectEqual(true, spuriousIrq(u8(15)));
+    expectEqual(true, spuriousIrq(15));
 
     // Post testing
-    expectEqual(u32(1), spurious_irq_counter);
+    expectEqual(@as(u32, 1), spurious_irq_counter);
 
     // Clean up
     spurious_irq_counter = 0;
@@ -712,11 +712,11 @@ test "setMask master IRQ masked" {
     defer arch.freeTest();
 
     // Going to assume all bits are masked out
-    arch.addTestParams("inb", MASTER_DATA_REG, u8(0xFF));
+    arch.addTestParams("inb", MASTER_DATA_REG, @as(u8, 0xFF));
     // Expect the 2nd bit to be set
-    arch.addTestParams("outb", MASTER_DATA_REG, u8(0xFF));
+    arch.addTestParams("outb", MASTER_DATA_REG, @as(u8, 0xFF));
 
-    setMask(u8(1));
+    setMask(1);
 }
 
 test "setMask master IRQ unmasked" {
@@ -725,11 +725,11 @@ test "setMask master IRQ unmasked" {
     defer arch.freeTest();
 
     // IRQ already unmasked
-    arch.addTestParams("inb", MASTER_DATA_REG, u8(0xFD));
+    arch.addTestParams("inb", MASTER_DATA_REG, @as(u8, 0xFD));
     // Expect the 2nd bit to be set
-    arch.addTestParams("outb", MASTER_DATA_REG, u8(0xFF));
+    arch.addTestParams("outb", MASTER_DATA_REG, @as(u8, 0xFF));
 
-    setMask(u8(1));
+    setMask(1);
 }
 
 test "clearMask master IRQ masked" {
@@ -738,11 +738,11 @@ test "clearMask master IRQ masked" {
     defer arch.freeTest();
 
     // Going to assume all bits are masked out
-    arch.addTestParams("inb", MASTER_DATA_REG, u8(0xFF));
+    arch.addTestParams("inb", MASTER_DATA_REG, @as(u8, 0xFF));
     // Expect the 2nd bit to be clear
-    arch.addTestParams("outb", MASTER_DATA_REG, u8(0xFD));
+    arch.addTestParams("outb", MASTER_DATA_REG, @as(u8, 0xFD));
 
-    clearMask(u8(1));
+    clearMask(1);
 }
 
 test "clearMask master IRQ unmasked" {
@@ -751,11 +751,11 @@ test "clearMask master IRQ unmasked" {
     defer arch.freeTest();
 
     // IRQ already unmasked
-    arch.addTestParams("inb", MASTER_DATA_REG, u8(0xFD));
+    arch.addTestParams("inb", MASTER_DATA_REG, @as(u8, 0xFD));
     // Expect the 2nd bit to still be clear
-    arch.addTestParams("outb", MASTER_DATA_REG, u8(0xFD));
+    arch.addTestParams("outb", MASTER_DATA_REG, @as(u8, 0xFD));
 
-    clearMask(u8(1));
+    clearMask(1);
 }
 
 test "init" {
@@ -783,9 +783,9 @@ test "init" {
         SLAVE_DATA_REG,
         ICW4_80x86_MODE,
         MASTER_DATA_REG,
-        u8(0xFF),
+        @as(u8, 0xFF),
         SLAVE_DATA_REG,
-        u8(0xFF),
+        @as(u8, 0xFF),
     );
 
     init();

--- a/src/kernel/arch/x86/pit.zig
+++ b/src/kernel/arch/x86/pit.zig
@@ -213,7 +213,7 @@ inline fn sendCommand(cmd: u8) void {
 ///
 inline fn readBackCommand(counter: CounterSelect) u8 {
     sendCommand(0xC2);
-    return u8(0x3F) & arch.inb(counter.getRegister());
+    return 0x3F & arch.inb(counter.getRegister());
 }
 
 ///
@@ -260,7 +260,7 @@ fn setupCounter(counter: CounterSelect, freq: u32, mode: u8) PitError!void {
     }
 
     // 65536, the slowest possible frequency. Roughly 19Hz
-    var reload_value = u32(0x10000);
+    var reload_value: u32 = 0x10000;
 
     // The lowest possible frequency is 18Hz.
     // MAX_FREQUENCY / 18 > u16 N
@@ -280,10 +280,10 @@ fn setupCounter(counter: CounterSelect, freq: u32, mode: u8) PitError!void {
     const frequency = (MAX_FREQUENCY + (reload_value / 2)) / reload_value;
 
     // Calculate the amount of nanoseconds between interrupts
-    time_ns = u32(1000000000) / frequency;
+    time_ns = 1000000000 / frequency;
 
     // Calculate the number of picoseconds, the left over from nanoseconds
-    time_under_1_ns = ((u32(1000000000) % frequency) * u32(1000) + (frequency / 2)) / frequency;
+    time_under_1_ns = ((1000000000 % frequency) * 1000 + (frequency / 2)) / frequency;
 
     // Set the frequency for the counter being set up
     switch (counter) {
@@ -316,11 +316,11 @@ fn setupCounter(counter: CounterSelect, freq: u32, mode: u8) PitError!void {
 ///     IN ticks_to_wait: u32 - The number of ticks to wait.
 ///
 pub fn waitTicks(ticks_to_wait: u32) void {
-    if (ticks > u32(maxInt(u32)) - ticks_to_wait) {
+    if (ticks > maxInt(u32) - ticks_to_wait) {
         // Integer overflow
 
         // Calculate the 2 conditions
-        const wait_ticks1 = u32(maxInt(u32)) - ticks;
+        const wait_ticks1 = maxInt(u32) - ticks;
         const wait_ticks2 = ticks_to_wait - wait_ticks1;
 
         while (ticks > wait_ticks1) {
@@ -372,7 +372,7 @@ pub fn getFrequency() u32 {
 pub fn init() void {
     log.logInfo("Init pit\n");
     // Set up counter 0 at 10000hz in a square wave mode counting in binary
-    const freq = u32(10000);
+    const freq: u32 = 10000;
     setupCounter(CounterSelect.Counter0, freq, OCW_MODE_SQUARE_WAVE_GENERATOR | OCW_BINARY_COUNT_BINARY) catch |e| {
         panic(@errorReturnTrace(), "Invalid frequency: {}\n", freq);
     };
@@ -398,7 +398,7 @@ test "sendCommand" {
     arch.initTest();
     defer arch.freeTest();
 
-    const cmd = u8(10);
+    const cmd: u8 = 10;
 
     arch.addTestParams("outb", COMMAND_REGISTER, cmd);
 
@@ -409,21 +409,21 @@ test "readBackCommand" {
     arch.initTest();
     defer arch.freeTest();
 
-    const cmd = u8(0xC2);
+    const cmd: u8 = 0xC2;
 
     arch.addTestParams("outb", COMMAND_REGISTER, cmd);
-    arch.addTestParams("inb", COUNTER_0_REGISTER, u8(0x20));
+    arch.addTestParams("inb", COUNTER_0_REGISTER, @as(u8, 0x20));
 
     const actual = readBackCommand(CounterSelect.Counter0);
 
-    expectEqual(u8(0x20), actual);
+    expectEqual(@as(u8, 0x20), actual);
 }
 
 test "sendDataToCounter" {
     arch.initTest();
     defer arch.freeTest();
 
-    const data = u8(10);
+    const data: u8 = 10;
 
     arch.addTestParams("outb", COUNTER_0_REGISTER, data);
 
@@ -437,13 +437,13 @@ test "setupCounter lowest frequency" {
     const counter = CounterSelect.Counter0;
     const port = counter.getRegister();
 
-    var freq = u32(0);
+    var freq: u32 = 0;
 
     // Reload value will be 0 (0x10000), the slowest speed for frequency less than 19
-    const expected_reload_value = u16(0);
+    const expected_reload_value: u16 = 0;
 
     // Slowest frequency the PIT can run at
-    const expected_freq = u32(19);
+    const expected_freq: u32 = 19;
 
     const mode = OCW_MODE_SQUARE_WAVE_GENERATOR | OCW_BINARY_COUNT_BINARY;
     const command = mode | OCW_READ_LOAD_DATA | counter.getCounterOCW();
@@ -514,7 +514,7 @@ test "setupCounter normal frequency" {
     // Set the frequency to a normal frequency
     const freq = 10000;
     const expected_reload_value = 119;
-    const expected_freq = u32(10027);
+    const expected_freq: u32 = 10027;
 
     const mode = OCW_MODE_SQUARE_WAVE_GENERATOR | OCW_BINARY_COUNT_BINARY;
     const command = mode | OCW_READ_LOAD_DATA | counter.getCounterOCW();
@@ -523,13 +523,13 @@ test "setupCounter normal frequency" {
 
     setupCounter(counter, freq, mode) catch unreachable;
 
-    expectEqual(u32(0), ticks);
+    expectEqual(@as(u32, 0), ticks);
     expectEqual(expected_freq, current_freq_0);
     expectEqual(expected_freq, getFrequency());
 
     // These are the hard coded expected values. Calculated externally to check the internal calculation
-    expectEqual(u32(99730), time_ns);
-    expectEqual(u32(727), time_under_1_ns);
+    expectEqual(@as(u32, 99730), time_ns);
+    expectEqual(@as(u32, 727), time_under_1_ns);
 
     // Reset globals
     time_ns = 0;
@@ -588,9 +588,9 @@ fn rt_waitTicks2() void {
 /// Check that when the PIT is initialised, counter 0 is set up properly.
 ///
 fn rt_initCounter_0() void {
-    const expected_ns = u32(99730);
-    const expected_ps = u32(727);
-    const expected_hz = u32(10027);
+    const expected_ns: u32 = 99730;
+    const expected_ps: u32 = 727;
+    const expected_hz: u32 = 10027;
 
     if (time_ns != expected_ns or time_under_1_ns != expected_ps or getFrequency() != expected_hz) {
         panic(

--- a/src/kernel/log.zig
+++ b/src/kernel/log.zig
@@ -36,7 +36,7 @@ pub fn runtimeTests() void {
     inline for (@typeInfo(Level).Enum.fields) |field| {
         const level = @field(Level, field.name);
         log(level, "Test " ++ field.name ++ " level\n");
-        log(level, "Test " ++ field.name ++ " level with args {}, {}\n", "a", u32(1));
+        log(level, "Test " ++ field.name ++ " level with args {}, {}\n", "a", @as(u32, 1));
         const logFn = switch (level) {
             .INFO => logInfo,
             .DEBUG => logDebug,
@@ -44,6 +44,6 @@ pub fn runtimeTests() void {
             .ERROR => logError,
         };
         logFn("Test " ++ field.name ++ " function\n");
-        logFn("Test " ++ field.name ++ " function with args {}, {}\n", "a", u32(1));
+        logFn("Test " ++ field.name ++ " function with args {}, {}\n", "a", @as(u32, 1));
     }
 }

--- a/src/kernel/mem.zig
+++ b/src/kernel/mem.zig
@@ -102,8 +102,8 @@ pub inline fn physToVirt(phys: var) @typeOf(phys) {
 test "physToVirt" {
     ADDR_OFFSET = 0xC0000000;
     const offset: usize = ADDR_OFFSET;
-    expectEqual(physToVirt(usize(0)), offset + 0);
-    expectEqual(physToVirt(usize(123)), offset + 123);
+    expectEqual(physToVirt(@as(usize, 0)), offset + 0);
+    expectEqual(physToVirt(@as(usize, 123)), offset + 123);
     expectEqual(@ptrToInt(physToVirt(@intToPtr(*usize, 123))), offset + 123);
 }
 

--- a/src/kernel/vga.zig
+++ b/src/kernel/vga.zig
@@ -186,7 +186,7 @@ inline fn getPortData(index: u8) u8 {
 ///     Both combined into 1 byte for the colour to be displayed.
 ///
 pub fn entryColour(fg: u4, bg: u4) u8 {
-    return u8(fg) | u8(bg) << 4;
+    return fg | @as(u8, bg) << 4;
 }
 
 ///
@@ -201,7 +201,7 @@ pub fn entryColour(fg: u4, bg: u4) u8 {
 ///     A VGA entry.
 ///
 pub fn entry(char: u8, colour: u8) u16 {
-    return u16(char) | u16(colour) << 8;
+    return char | @as(u16, colour) << 8;
 }
 
 ///
@@ -237,10 +237,10 @@ pub fn updateCursor(x: u16, y: u16) void {
 ///     The linear cursor position.
 ///
 pub fn getCursor() u16 {
-    var cursor = u16(0);
+    var cursor: u16 = 0;
 
-    cursor |= u16(getPortData(REG_CURSOR_LOCATION_LOW));
-    cursor |= u16(getPortData(REG_CURSOR_LOCATION_HIGH)) << 8;
+    cursor |= getPortData(REG_CURSOR_LOCATION_LOW);
+    cursor |= @as(u16, getPortData(REG_CURSOR_LOCATION_HIGH)) << 8;
 
     return cursor;
 }
@@ -303,34 +303,34 @@ test "entryColour" {
     var fg = COLOUR_BLACK;
     var bg = COLOUR_BLACK;
     var res = entryColour(fg, bg);
-    expectEqual(u8(0x00), res);
+    expectEqual(@as(u8, 0x00), res);
 
     fg = COLOUR_LIGHT_GREEN;
     bg = COLOUR_BLACK;
     res = entryColour(fg, bg);
-    expectEqual(u8(0x0A), res);
+    expectEqual(@as(u8, 0x0A), res);
 
     fg = COLOUR_BLACK;
     bg = COLOUR_LIGHT_GREEN;
     res = entryColour(fg, bg);
-    expectEqual(u8(0xA0), res);
+    expectEqual(@as(u8, 0xA0), res);
 
     fg = COLOUR_BROWN;
     bg = COLOUR_LIGHT_GREEN;
     res = entryColour(fg, bg);
-    expectEqual(u8(0xA6), res);
+    expectEqual(@as(u8, 0xA6), res);
 }
 
 test "entry" {
     const colour = entryColour(COLOUR_BROWN, COLOUR_LIGHT_GREEN);
-    expectEqual(u8(0xA6), colour);
+    expectEqual(@as(u8, 0xA6), colour);
 
     // Character '0' is 0x30
     var video_entry = entry('0', colour);
-    expectEqual(u16(0xA630), video_entry);
+    expectEqual(@as(u16, 0xA630), video_entry);
 
     video_entry = entry(0x55, colour);
-    expectEqual(u16(0xA655), video_entry);
+    expectEqual(@as(u16, 0xA655), video_entry);
 }
 
 test "updateCursor width out of bounds" {
@@ -419,8 +419,8 @@ test "updateCursor width and height-1 out of bounds" {
 }
 
 test "updateCursor in bounds" {
-    var x = u8(0x0A);
-    var y = u8(0x0A);
+    var x: u8 = 0x0A;
+    var y: u8 = 0x0A;
     const expected = y * WIDTH + x;
 
     var expected_upper = @truncate(u8, (expected >> 8) & 0x00FF);
@@ -435,32 +435,32 @@ test "updateCursor in bounds" {
 }
 
 test "getCursor 1: 10" {
-    const expect = u16(10);
+    const expect: u16 = 10;
 
     // Mocking out the arch.outb and arch.inb calls for getting the hardware cursor:
     arch.initTest();
     defer arch.freeTest();
 
     arch.addTestParams("outb", PORT_ADDRESS, REG_CURSOR_LOCATION_LOW);
-    arch.addTestParams("inb", PORT_DATA, u8(10));
+    arch.addTestParams("inb", PORT_DATA, @as(u8, 10));
     arch.addTestParams("outb", PORT_ADDRESS, REG_CURSOR_LOCATION_HIGH);
-    arch.addTestParams("inb", PORT_DATA, u8(0));
+    arch.addTestParams("inb", PORT_DATA, @as(u8, 0));
 
     const actual = getCursor();
     expectEqual(expect, actual);
 }
 
 test "getCursor 2: 0xBEEF" {
-    const expect = u16(0xBEEF);
+    const expect: u16 = 0xBEEF;
 
     // Mocking out the arch.outb and arch.inb calls for getting the hardware cursor:
     arch.initTest();
     defer arch.freeTest();
 
     arch.addTestParams("outb", PORT_ADDRESS, REG_CURSOR_LOCATION_LOW);
-    arch.addTestParams("inb", PORT_DATA, u8(0xEF));
+    arch.addTestParams("inb", PORT_DATA, @as(u8, 0xEF));
     arch.addTestParams("outb", PORT_ADDRESS, REG_CURSOR_LOCATION_HIGH);
-    arch.addTestParams("inb", PORT_DATA, u8(0xBE));
+    arch.addTestParams("inb", PORT_DATA, @as(u8, 0xBE));
 
     const actual = getCursor();
     expectEqual(expect, actual);
@@ -563,8 +563,8 @@ fn rt_correctCursorShape() void {
 ///
 fn rt_setCursorGetCursor() void {
     // The known locations
-    const x = u16(10);
-    const y = u16(20);
+    const x: u16 = 10;
+    const y: u16 = 20;
 
     // Save the previous location
     const prev_linear_loc = getCursor();

--- a/test/mock/kernel/mock_framework.zig
+++ b/test/mock/kernel/mock_framework.zig
@@ -293,7 +293,7 @@ fn Mock() type {
 
             // Test that the types match
             const expect_type = comptime getDataElementType(ExpectedType);
-            expectEqual(expect_type, DataElementType(elem));
+            expectEqual(expect_type, @as(DataElementType, elem));
 
             // Types match, so can use the expected type to get the actual data
             const actual_value = getDataValue(ExpectedType, elem);
@@ -323,7 +323,7 @@ fn Mock() type {
 
                 const ret = getDataValue(DataType, action.data);
 
-                expectEqual(DataElementType(action.data), expect_type);
+                expectEqual(@as(DataElementType, action.data), expect_type);
 
                 // Free the node
                 action_list.*.destroyNode(action_node, GlobalAllocator);
@@ -429,7 +429,7 @@ fn Mock() type {
                             const expect_type = comptime getDataElementType(expected_function);
 
                             // Test that the types match
-                            expectEqual(expect_type, DataElementType(test_element));
+                            expectEqual(expect_type, @as(DataElementType, test_element));
 
                             // Types match, so can use the expected type to get the actual data
                             const actual_function = getDataValue(expected_function, test_element);
@@ -462,7 +462,7 @@ fn Mock() type {
                             const expect_type = comptime getDataElementType(expected_function);
 
                             // Test that the types match
-                            expectEqual(expect_type, DataElementType(test_element));
+                            expectEqual(expect_type, @as(DataElementType, test_element));
 
                             // Types match, so can use the expected type to get the actual data
                             const actual_function = getDataValue(expected_function, test_element);
@@ -520,7 +520,7 @@ fn Mock() type {
                     switch (action.action) {
                         ActionType.TestValue, ActionType.ConsumeFunctionCall => {
                             // These need to be all consumed
-                            std.debug.panic("Unused testing value: Type: {}, value: {} for function '{}'\n", action.action, DataElementType(action.data), next.key);
+                            std.debug.panic("Unused testing value: Type: {}, value: {} for function '{}'\n", action.action, @as(DataElementType, action.data), next.key);
                         },
                         ActionType.RepeatFunctionCall => {
                             // As this is a repeat action, the function will still be here

--- a/test/mock/kernel/vga_mock.zig
+++ b/test/mock/kernel/vga_mock.zig
@@ -70,11 +70,11 @@ pub fn init() void {
 // User defined mocked functions
 
 pub fn orig_entryColour(fg: u4, bg: u4) u8 {
-    return u8(fg) | u8(bg) << 4;
+    return fg | @as(u8, bg) << 4;
 }
 
 pub fn orig_entry(uc: u8, c: u8) u16 {
-    return u16(uc) | u16(c) << 8;
+    return uc | @as(u16, c) << 8;
 }
 
 pub fn mock_updateCursor(x: u16, y: u16) void {


### PR DESCRIPTION
This patch fixes the `T(x)` style casts in the codebase. Unnecessary casts were removed, those of the form `const/var x = T(y)` were replaced with `const/var x: T = y` and other were replaced with the new `@as` builtin. Closes #110 