### PR TITLE
Change CI's zig version to 0.5.0+ae0a219d1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Download zig
       run: |
         export PYTHONIOENCODING=utf8
-        wget $(curl -s 'https://ziglang.org/download/index.json' | python3 -c "import sys, json; print(json.load(sys.stdin)['master']['x86_64-linux']['tarball'])")
+        wget https://ziglang.org/builds/zig-0.5.0+ae0a219d1.tar.xz
         sudo apt-get install mtools
         tar -xvf zig*
     - name: Build kernel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Download zig
       run: |
         export PYTHONIOENCODING=utf8
-        wget https://ziglang.org/builds/zig-0.5.0+ae0a219d1.tar.xz
+        wget https://ziglang.org/builds/zig-linux-x86_64-0.5.0+ae0a219d1.tar.xz
         sudo apt-get install mtools
         tar -xvf zig*
     - name: Build kernel


### PR DESCRIPTION
This patch changes the version of zig used in CI to 0.5.0+ae0a219d1. Closes #112