### PR TITLE
Hotfix/callconv changes

### DIFF
--- a/src/kernel/arch/x86/boot.zig
+++ b/src/kernel/arch/x86/boot.zig
@@ -66,7 +66,7 @@ export var kernel_stack: [16 * 1024]u8 align(16) linksection(".bss.stack") = und
 
 extern fn kmain() void;
 
-export nakedcc fn _start() align(16) linksection(".text.boot") noreturn {
+export fn _start() align(16) linksection(".text.boot") callconv(.Naked) noreturn {
     // Set the page directory to the boot directory
     asm volatile (
         \\.extern boot_page_directory
@@ -91,7 +91,7 @@ export nakedcc fn _start() align(16) linksection(".text.boot") noreturn {
     while (true) {}
 }
 
-export nakedcc fn start_higher_half() noreturn {
+export fn start_higher_half() callconv(.Naked) noreturn {
     // Invalidate the page for the first 4MiB as it's no longer needed
     asm volatile ("invlpg (0)");
 

--- a/src/kernel/arch/x86/idt.zig
+++ b/src/kernel/arch/x86/idt.zig
@@ -48,7 +48,7 @@ pub const IdtPtr = packed struct {
     base: u32,
 };
 
-pub const InterruptHandler = nakedcc fn () void;
+pub const InterruptHandler = fn () callconv(.Naked) void;
 
 /// The error set for the IDT
 pub const IdtError = error{
@@ -189,8 +189,8 @@ pub fn init() void {
     if (build_options.rt_test) runtimeTests();
 }
 
-nakedcc fn testHandler0() void {}
-nakedcc fn testHandler1() void {}
+fn testHandler0() callconv(.Naked) void {}
+fn testHandler1() callconv(.Naked) void {}
 
 fn mock_lidt(ptr: *const IdtPtr) void {
     expectEqual(TABLE_SIZE, ptr.limit);

--- a/src/kernel/arch/x86/interrupts.zig
+++ b/src/kernel/arch/x86/interrupts.zig
@@ -25,7 +25,7 @@ export fn handler(ctx: *arch.InterruptContext) void {
 ///
 /// The common assembly that all exceptions and interrupts will call.
 ///
-export nakedcc fn commonStub() void {
+export fn commonStub() callconv(.Naked) void {
     asm volatile (
         \\pusha
         \\push  %%ds
@@ -63,7 +63,7 @@ export nakedcc fn commonStub() void {
 ///
 pub fn getInterruptStub(comptime interrupt_num: u32) idt.InterruptHandler {
     return struct {
-        nakedcc fn func() void {
+        fn func() callconv(.Naked) void {
             asm volatile (
                 \\ cli
             );

--- a/src/kernel/arch/x86/irq.zig
+++ b/src/kernel/arch/x86/irq.zig
@@ -140,7 +140,7 @@ pub fn init() void {
     if (build_options.rt_test) runtimeTests();
 }
 
-nakedcc fn testFunction0() void {}
+fn testFunction0() callconv(.Naked) void {}
 fn testFunction1(ctx: *arch.InterruptContext) void {}
 fn testFunction2(ctx: *arch.InterruptContext) void {}
 

--- a/src/kernel/arch/x86/isr.zig
+++ b/src/kernel/arch/x86/isr.zig
@@ -248,7 +248,7 @@ pub fn init() void {
     if (build_options.rt_test) runtimeTests();
 }
 
-nakedcc fn testFunction0() void {}
+fn testFunction0() callconv(.Naked) void {}
 fn testFunction1(ctx: *arch.InterruptContext) void {}
 fn testFunction2(ctx: *arch.InterruptContext) void {}
 fn testFunction3(ctx: *arch.InterruptContext) void {}

--- a/test/mock/kernel/mock_framework.zig
+++ b/test/mock/kernel/mock_framework.zig
@@ -55,7 +55,7 @@ const DataElement = union(DataElementType) {
     PTR_CONST_IdtPtr: *const idt.IdtPtr,
     ERROR_IDTERROR_VOID: idt.IdtError!void,
     EFN_OVOID: extern fn () void,
-    NFN_OVOID: nakedcc fn () void,
+    NFN_OVOID: fn () callconv(.Naked) void,
     FN_OVOID: fn () void,
     FN_OUSIZE: fn () usize,
     FN_OU16: fn () u16,
@@ -68,7 +68,7 @@ const DataElement = union(DataElementType) {
     FN_IU16_IU8_OVOID: fn (u16, u8) void,
     FN_IU16_IU16_OVOID: fn (u16, u16) void,
     FN_IU8_IEFNOVOID_OERRORIDTERRORVOID: fn (u8, extern fn () void) idt.IdtError!void,
-    FN_IU8_INFNOVOID_OERRORIDTERRORVOID: fn (u8, nakedcc fn () void) idt.IdtError!void,
+    FN_IU8_INFNOVOID_OERRORIDTERRORVOID: fn (u8, fn () callconv(.Naked) void) idt.IdtError!void,
     FN_IPTRCONSTGDTPTR_OVOID: fn (*const gdt.GdtPtr) void,
     FN_IPTRCONSTIDTPTR_OVOID: fn (*const idt.IdtPtr) void,
 };
@@ -155,7 +155,7 @@ fn Mock() type {
                 *const idt.IdtPtr => DataElement{ .PTR_CONST_IdtPtr = arg },
                 idt.IdtError!void => DataElement{ .ERROR_IDTERROR_VOID = arg },
                 extern fn () void => DataElement{ .EFN_OVOID = arg },
-                nakedcc fn () void => DataElement{ .NFN_OVOID = arg },
+                fn () callconv(.Naked) void => DataElement{ .NFN_OVOID = arg },
                 fn () void => DataElement{ .FN_OVOID = arg },
                 fn () usize => DataElement{ .FN_OUSIZE = arg },
                 fn () u16 => DataElement{ .FN_OU16 = arg },
@@ -170,7 +170,7 @@ fn Mock() type {
                 fn (*const gdt.GdtPtr) void => DataElement{ .FN_IPTRCONSTGDTPTR_OVOID = arg },
                 fn (*const idt.IdtPtr) void => DataElement{ .FN_IPTRCONSTIDTPTR_OVOID = arg },
                 fn (u8, extern fn () void) idt.IdtError!void => DataElement{ .FN_IU8_IEFNOVOID_OERRORIDTERRORVOID = arg },
-                fn (u8, nakedcc fn () void) idt.IdtError!void => DataElement{ .FN_IU8_INFNOVOID_OERRORIDTERRORVOID = arg },
+                fn (u8, fn () callconv(.Naked) void) idt.IdtError!void => DataElement{ .FN_IU8_INFNOVOID_OERRORIDTERRORVOID = arg },
                 else => @compileError("Type not supported: " ++ @typeName(@TypeOf(arg))),
             };
         }
@@ -195,7 +195,7 @@ fn Mock() type {
                 *const idt.IdtPtr => DataElement.PTR_CONST_IdtPtr,
                 idt.IdtError!void => DataElement.ERROR_IDTERROR_VOID,
                 extern fn () void => DataElementType.EFN_OVOID,
-                nakedcc fn () void => DataElementType.NFN_OVOID,
+                fn () callconv(.Naked) void => DataElementType.NFN_OVOID,
                 fn () void => DataElementType.FN_OVOID,
                 fn () u16 => DataElementType.FN_OU16,
                 fn (u8) bool => DataElementType.FN_IU8_OBOOL,
@@ -209,7 +209,7 @@ fn Mock() type {
                 fn (*const gdt.GdtPtr) void => DataElementType.FN_IPTRCONSTGDTPTR_OVOID,
                 fn (*const idt.IdtPtr) void => DataElementType.FN_IPTRCONSTIDTPTR_OVOID,
                 fn (u8, extern fn () void) idt.IdtError!void => DataElementType.FN_IU8_IEFNOVOID_OERRORIDTERRORVOID,
-                fn (u8, nakedcc fn () void) idt.IdtError!void => DataElementType.FN_IU8_INFNOVOID_OERRORIDTERRORVOID,
+                fn (u8, fn () callconv(.Naked) void) idt.IdtError!void => DataElementType.FN_IU8_INFNOVOID_OERRORIDTERRORVOID,
                 else => @compileError("Type not supported: " ++ @typeName(T)),
             };
         }
@@ -236,7 +236,7 @@ fn Mock() type {
                 *const idt.IdtPtr => element.PTR_CONST_IdtPtr,
                 idt.IdtError!void => element.ERROR_IDTERROR_VOID,
                 extern fn () void => element.EFN_OVOID,
-                nakedcc fn () void => element.NFN_OVOID,
+                fn () callconv(.Naked) void => element.NFN_OVOID,
                 fn () void => element.FN_OVOID,
                 fn () u16 => element.FN_OU16,
                 fn (u8) bool => element.FN_IU8_OBOOL,
@@ -250,7 +250,7 @@ fn Mock() type {
                 fn (*const gdt.GdtPtr) void => element.FN_IPTRCONSTGDTPTR_OVOID,
                 fn (*const idt.IdtPtr) void => element.FN_IPTRCONSTIDTPTR_OVOID,
                 fn (u8, extern fn () void) idt.IdtError!void => element.FN_IU8_IEFNOVOID_OERRORIDTERRORVOID,
-                fn (u8, nakedcc fn () void) idt.IdtError!void => element.FN_IU8_INFNOVOID_OERRORIDTERRORVOID,
+                fn (u8, fn () callconv(.Naked) void) idt.IdtError!void => element.FN_IU8_INFNOVOID_OERRORIDTERRORVOID,
                 else => @compileError("Type not supported: " ++ @typeName(T)),
             };
         }


### PR DESCRIPTION
This updates the calling convention syntax as of ziglang/zig@5951b79

