### PR TITLE
Keep stack section

### DIFF
--- a/link.ld
+++ b/link.ld
@@ -35,7 +35,7 @@ SECTIONS {
 	}
 
 	.bss.stack ALIGN(4K) : AT (ADDR(.bss.stack) - KERNEL_ADDR_OFFSET) {
-		*(.bss.stack)
+		KEEP(*(.bss.stack))
         KERNEL_STACK_END = .;
     }
 


### PR DESCRIPTION
This patch makes sure the linker keeps the stack section, preventing it from being discarded in case there are no explicit uses. Closes #125

Depends on #127