### PR TITLE
use /usr/bin/env bash instead of /bin/bash

### DIFF
--- a/makeiso.sh
+++ b/makeiso.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BOOT_DIR=$1
 MODULES_DIR=$2


### PR DESCRIPTION
`!/usr/bin/env bash` works on more systems than `!/bin/bash`.  I use NixOS which doesn't have `/bin/bash` and I know some BSDs also don't have `/bin/bash`.