### PR TITLE
Use the standardTargetOptions for built targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ zig build
 ```Shell
 zig build run
 ```
+
 or if you want to wait for a gdb connection:
+
 ```Shell
 zig build debug-run
 ```
@@ -68,9 +70,8 @@ Available test modes:
 * `-D[build-mode]=`: Boolean (default `false`).
   * **build**: Build a certain build mode (*release-safe*, *release-fast*, *release-small*). Don't set in order to use the *debug* build mode.
   * **test**: Test a certain build mode (*release-safe*, *release-fast*, *release-small*). Don't set in order to use the *debug* build mode.
-* `-Darch=`: String (default `x86`). Currently the only supported value is `x86`.
-  * **build**: Build for a certain architecture.
-  * **test**: Test a certain architecture.
+* `-Dtarget=`: String (default `i386-freestanding`). The standard target options for building with zig. Currently supported targets:
+  * `i386-freestanding`
 * `-Ddisable-display`: Boolean (default `false`)
   * This disables the display output of QEMU.
 

--- a/build.zig
+++ b/build.zig
@@ -19,12 +19,10 @@ const x86_i686 = CrossTarget{
 };
 
 pub fn build(b: *Builder) !void {
-    const arch = b.option([]const u8, "arch", "Architecture to build for: x86") orelse "x86";
-    const target: CrossTarget = if (std.mem.eql(u8, "x86", arch))
-        x86_i686
-    else {
-        std.debug.warn("Unsupported or unknown architecture '{}'\n", .{arch});
-        unreachable;
+    const target = b.standardTargetOptions(.{ .whitelist = &[_]CrossTarget{x86_i686}, .default_target = x86_i686 });
+    const arch = switch (target.getCpuArch()) {
+        .i386 => "x86",
+        else => unreachable,
     };
 
     const fmt_step = b.addFmt(&[_][]const u8{


### PR DESCRIPTION
This will allow the user to build the OS with more fine grain, but there is a white list of supported build targets.
Closes #129