### PR TITLE
Replace buddy allocator with free list allocator

### DIFF
--- a/src/kernel/kmain.zig
+++ b/src/kernel/kmain.zig
@@ -61,7 +61,7 @@ export fn kmain(boot_payload: arch.BootPayload) void {
     if (!std.math.isPowerOfTwo(heap_size)) {
         heap_size = std.math.floorPowerOfTwo(usize, heap_size);
     }
-    var kernel_heap = heap.init(arch.VmmPayload, &kernel_vmm, vmm.Attributes{ .kernel = true, .writable = true, .cachable = true }, heap_size, &fixed_allocator.allocator) catch |e| {
+    var kernel_heap = heap.init(arch.VmmPayload, &kernel_vmm, vmm.Attributes{ .kernel = true, .writable = true, .cachable = true }, heap_size) catch |e| {
         panic_root.panic(@errorReturnTrace(), "Failed to initialise kernel heap: {}\n", .{e});
     };
     tty.init(&kernel_heap.allocator, boot_payload);


### PR DESCRIPTION
This patch adds a new allocator which uses a free list over a buddy system. Once this PR is done I will fully replace heap.zig with heap2.zig. Let me know if the design is unclear or if any of the code could be cleaned up since it is quite complex atm.﻿
